### PR TITLE
Add satnam static site under /satnam/ path

### DIFF
--- a/public/satnam/artikel/sat-nam-rasayan-vs-reiki.html
+++ b/public/satnam/artikel/sat-nam-rasayan-vs-reiki.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sat Nam Rasayan vs. Reiki: Was ist der Unterschied? Ehrlicher Vergleich 2026</title>
+  <meta name="description" content="Sat Nam Rasayan oder Reiki? Beide arbeiten mit Bewusstsein und Heilung – aber der Ansatz ist grundlegend verschieden. Ein ehrlicher Vergleich mit Tabelle.">
+  <link rel="canonical" href="https://example.com/artikel/sat-nam-rasayan-vs-reiki.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+
+  <nav class="nav" id="nav">
+    <div class="nav__inner">
+      <a href="/satnam/" class="nav__logo">
+        <span class="nav__logo-mark">◯</span>
+        <span class="nav__logo-text">Sat Nam Rasayan</span>
+      </a>
+      <button class="nav__toggle" id="navToggle" aria-label="Menü öffnen">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="nav__links" id="navLinks">
+        <li><a href="/satnam/artikel/was-ist-sat-nam-rasayan.html">Was ist SNR?</a></li>
+        <li><a href="/satnam/artikel/sat-nam-rasayan-vs-reiki.html">SNR vs. Reiki</a></li>
+        <li><a href="/satnam/artikel/sat-kriya-anleitung.html">Sat Kriya</a></li>
+        <li><a href="/satnam/blog.html">Blog</a></li>
+        <li><a href="/satnam/glossar.html">Glossar</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <header class="article-hero">
+    <nav class="article-hero__breadcrumb" aria-label="Breadcrumb">
+      <a href="/satnam/">Start</a> › <a href="/satnam/blog.html">Artikel</a> › SNR vs. Reiki
+    </nav>
+    <span class="article-hero__tag">Vergleich</span>
+    <h1>Sat Nam Rasayan vs. Reiki: Was ist der Unterschied?</h1>
+    <div class="article-hero__meta">
+      <span>Aktualisiert: März 2026</span>
+      <span>·</span>
+      <span>10 Min. Lesezeit</span>
+    </div>
+  </header>
+
+  <article class="article-content">
+
+    <p>
+      Wer sich für energetische Heilmethoden interessiert, stößt früher oder später auf zwei Namen: 
+      Reiki und Sat Nam Rasayan. Äußerlich ähneln sich beide – der Klient liegt entspannt, der 
+      Praktizierende arbeitet im Stillen. Doch hinter der äußeren Ähnlichkeit verbergen sich 
+      grundlegend verschiedene Ansätze. Dieser Vergleich hilft dir, die Methode zu finden, die 
+      zu dir passt.
+    </p>
+
+    <h2>Der Vergleich auf einen Blick</h2>
+
+    <table class="comparison-table">
+      <thead>
+        <tr>
+          <th>Kriterium</th>
+          <th>Sat Nam Rasayan</th>
+          <th>Reiki</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Herkunft</strong></td>
+          <td>Kundalini Yoga Tradition (Indien/Tibet), öffentlich seit 1993</td>
+          <td>Japan, entwickelt ca. 1922 von Mikao Usui</td>
+        </tr>
+        <tr>
+          <td><strong>Grundprinzip</strong></td>
+          <td>Heilung durch meditative Präsenz und Stille (Shuniya)</td>
+          <td>Heilung durch Kanalisierung universeller Lebensenergie (Ki/Chi)</td>
+        </tr>
+        <tr>
+          <td><strong>Energiearbeit</strong></td>
+          <td>Keine Energie wird gesendet – der Praktizierende arbeitet in seiner eigenen Wahrnehmung</td>
+          <td>Energie wird gezielt über die Hände des Praktizierenden gesendet</td>
+        </tr>
+        <tr>
+          <td><strong>Berührung</strong></td>
+          <td>Minimale Berührung (oft nur Arm), auch ohne Kontakt möglich</td>
+          <td>Handpositionen auf oder über verschiedenen Körperbereichen</td>
+        </tr>
+        <tr>
+          <td><strong>Meditativer Zustand</strong></td>
+          <td>Tiefer meditativer Zustand (Shuniya) zentral für die Praxis</td>
+          <td>Entspannter, aber nicht zwingend tief meditativer Zustand</td>
+        </tr>
+        <tr>
+          <td><strong>Symbole / Rituale</strong></td>
+          <td>Keine Symbole, keine Rituale, keine Einweihung</td>
+          <td>Spezifische Symbole und Einweihungsrituale (Attunements)</td>
+        </tr>
+        <tr>
+          <td><strong>Ausbildungsdauer</strong></td>
+          <td>Stufe 1: ca. 1 Jahr (12 Tage), Stufe 2: ca. 2,5 Jahre</td>
+          <td>Je nach System: 1. Grad oft 1–2 Wochenenden, 2. Grad ähnlich</td>
+        </tr>
+        <tr>
+          <td><strong>Fernbehandlung</strong></td>
+          <td>Ja, von Anfang an möglich</td>
+          <td>Ja, ab dem 2. Grad</td>
+        </tr>
+        <tr>
+          <td><strong>Kosten Einzelsitzung</strong></td>
+          <td>ca. 75–100 € (60 Min.)</td>
+          <td>ca. 50–90 € (60 Min.)</td>
+        </tr>
+        <tr>
+          <td><strong>Verbreitung in D</strong></td>
+          <td>Nische – Schulen in Berlin, Düsseldorf, München</td>
+          <td>Weit verbreitet – Praktizierende in den meisten Städten</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Der entscheidende Unterschied: „Tun" vs. „Sein"</h2>
+
+    <p>
+      Der fundamentalste Unterschied zwischen den beiden Methoden liegt im Verhältnis des 
+      Praktizierenden zur Heilung selbst.
+    </p>
+
+    <p>
+      Im <strong>Reiki</strong> ist der Praktizierende ein Kanal: Er empfängt universelle 
+      Lebensenergie und leitet sie über seine Hände an den Klienten weiter. Es gibt festgelegte 
+      Handpositionen, Symbole und eine klare Vorstellung davon, dass Energie „fließt" und 
+      „gesendet" wird.
+    </p>
+
+    <p>
+      Im <strong>Sat Nam Rasayan</strong> geschieht etwas anderes: Der Praktizierende „tut" 
+      im eigentlichen Sinne nichts. Er geht in einen Zustand tiefer meditativer Stille und 
+      wird gewahr, was sich in der Beziehung zum Klienten zeigt. Durch das reine Wahrnehmen 
+      und Zulassen lösen sich Widerstände auf. Man könnte sagen: In Reiki ist der Praktizierende 
+      ein Kanal, in Sat Nam Rasayan ist er ein Spiegel.
+    </p>
+
+    <blockquote>
+      <p>„Sat Nam Rasayan is beyond the mind. It is not Reiki, Pranic Healing, or any other 
+      kind of energy work. It is what it is."</p>
+    </blockquote>
+
+    <h2>Gemeinsamkeiten</h2>
+
+    <p>
+      Trotz der unterschiedlichen Ansätze gibt es durchaus Überschneidungen, die beide 
+      Methoden verbinden: Beide arbeiten im Setting einer Einzelsitzung mit liegendem Klienten. 
+      Beide zielen auf tiefe Entspannung und die Aktivierung der Selbstheilungskräfte ab. 
+      Beide können als Ergänzung zur Schulmedizin eingesetzt werden, nicht als Ersatz. 
+      Und bei beiden berichten Klienten von ähnlichen Erfahrungen: Wärme, Leichtigkeit, 
+      emotionale Lösung und körperliche Entspannung.
+    </p>
+
+    <h2>Für wen eignet sich was?</h2>
+
+    <p>
+      <strong>Reiki könnte besser passen, wenn du:</strong> einen niedrigschwelligen Einstieg 
+      in die Energiearbeit suchst, die Vorstellung magst, dass Energie aktiv gelenkt wird, 
+      gerne mit Symbolen und strukturierten Ritualen arbeitest, oder in kurzer Zeit eine 
+      Grundausbildung absolvieren möchtest.
+    </p>
+
+    <p>
+      <strong>Sat Nam Rasayan könnte besser passen, wenn du:</strong> Meditation und 
+      Bewusstseinsarbeit in den Mittelpunkt stellen willst, einen Ansatz bevorzugst, der 
+      frei von Dogmen, Symbolen und Ritualen ist, bereit bist, dich auf eine längere, 
+      tiefgreifende Ausbildung einzulassen, oder bereits Kundalini Yoga praktizierst und 
+      deine meditative Praxis vertiefen möchtest.
+    </p>
+
+    <div class="info-box">
+      <h4>Kein „besser" oder „schlechter"</h4>
+      <p>
+        Beide Methoden haben ihre Berechtigung und können kraftvoll wirken. 
+        Die „richtige" Methode ist die, die sich für dich stimmig anfühlt. 
+        Am besten probierst du beide aus und spürst, was resoniert.
+      </p>
+    </div>
+
+    <h2>Kann man beides kombinieren?</h2>
+
+    <p>
+      Ja. Sat Nam Rasayan kann grundsätzlich mit anderen Meditations- und Heilmethoden 
+      kombiniert werden. Manche Praktizierende haben sowohl eine Reiki- als auch eine 
+      Sat Nam Rasayan-Ausbildung und integrieren Elemente beider Traditionen in ihre Arbeit. 
+      Die feinere Wahrnehmung, die durch Sat Nam Rasayan entwickelt wird, kann sogar 
+      dazu beitragen, mit jedem therapeutischen Ansatz präziser zu arbeiten.
+    </p>
+
+    <h2>Weiterführende Artikel</h2>
+    <ul>
+      <li><a href="/satnam/artikel/was-ist-sat-nam-rasayan.html">Was ist Sat Nam Rasayan? Der komplette Guide</a></li>
+      <li><a href="/satnam/artikel/sat-nam-rasayan-erfahrungen.html">Erfahrungen: Was passiert bei einer SNR Behandlung?</a></li>
+      <li><a href="/satnam/glossar.html#shuniya">Glossar: Was ist Shuniya?</a></li>
+    </ul>
+
+  </article>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer__grid">
+        <div class="footer__brand">
+          <span class="nav__logo-mark">◯</span>
+          <span class="nav__logo-text">Sat Nam Rasayan</span>
+          <p class="footer__tagline">Heilung durch innere Stille.<br>Wissen für den deutschsprachigen Raum.</p>
+        </div>
+        <div class="footer__col">
+          <h4>Sat Nam Rasayan</h4>
+          <ul>
+            <li><a href="/satnam/artikel/was-ist-sat-nam-rasayan.html">Was ist SNR?</a></li>
+            <li><a href="/satnam/artikel/sat-nam-rasayan-vs-reiki.html">SNR vs. Reiki</a></li>
+            <li><a href="/satnam/artikel/sat-nam-rasayan-erfahrungen.html">Erfahrungen</a></li>
+          </ul>
+        </div>
+        <div class="footer__col">
+          <h4>Kundalini Kriyas</h4>
+          <ul>
+            <li><a href="/satnam/artikel/sat-kriya-anleitung.html">Sat Kriya</a></li>
+            <li><a href="/satnam/artikel/40-tage-kriya-challenge.html">40-Tage-Challenge</a></li>
+            <li><a href="/satnam/artikel/kriya-gegen-angst.html">Kriya gegen Angst</a></li>
+          </ul>
+        </div>
+        <div class="footer__col">
+          <h4>Mehr</h4>
+          <ul>
+            <li><a href="/satnam/glossar.html">Glossar</a></li>
+            <li><a href="/satnam/blog.html">Alle Artikel</a></li>
+            <li><a href="/satnam/impressum.html">Impressum</a></li>
+            <li><a href="/satnam/datenschutz.html">Datenschutz</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer__bottom">
+        <p>© 2026 Sat Nam Rasayan Wissen. Kein Ersatz für medizinische Beratung.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/main.js"></script>
+</body>
+</html>

--- a/public/satnam/artikel/was-ist-sat-nam-rasayan.html
+++ b/public/satnam/artikel/was-ist-sat-nam-rasayan.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Was ist Sat Nam Rasayan? Die meditative Heilkunst einfach erklärt</title>
+  <meta name="description" content="Sat Nam Rasayan ist eine meditative Heilkunst aus dem Kundalini Yoga. Erfahre, wie sie funktioniert, was bei einer Behandlung passiert und für wen sie geeignet ist.">
+  <link rel="canonical" href="https://example.com/artikel/was-ist-sat-nam-rasayan.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+
+  <!-- FAQ Schema -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Was ist Sat Nam Rasayan?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Sat Nam Rasayan ist eine meditative Heilkunst aus der Tradition des Kundalini Yoga. Der Praktizierende nutzt ausschließlich seine meditative Präsenz und Aufmerksamkeit, um Blockaden im Klienten zu lösen. Es wird keine Energie gesendet oder visualisiert."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Wie funktioniert eine Sat Nam Rasayan Behandlung?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Der Klient liegt entspannt auf einer Matte. Der Praktizierende sitzt daneben, berührt leicht den Arm des Klienten und geht in einen tiefen meditativen Zustand (Shuniya). In dieser Stille werden Widerstände und Blockaden wahrgenommen und aufgelöst."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Brauche ich Yoga-Erfahrung für Sat Nam Rasayan?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Nein. Für eine Behandlung als Klient sind keinerlei Vorkenntnisse nötig. Auch die Ausbildung zum Practitioner erfordert keine vorherige Yoga-Erfahrung."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Was kostet eine Sat Nam Rasayan Behandlung?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Eine Einzelbehandlung von ca. 60 Minuten kostet in Deutschland zwischen 75 und 100 Euro. Fernbehandlungen sind oft im gleichen Preisbereich."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Ist Sat Nam Rasayan das gleiche wie Reiki?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Nein. Obwohl beide Methoden im Setting ähnlich wirken, unterscheiden sie sich grundlegend: Reiki arbeitet mit dem gezielten Senden von Energie, während Sat Nam Rasayan ausschließlich mit meditativer Präsenz und Stille arbeitet, ohne Energie zu lenken."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav" id="nav">
+    <div class="nav__inner">
+      <a href="/satnam/" class="nav__logo">
+        <span class="nav__logo-mark">◯</span>
+        <span class="nav__logo-text">Sat Nam Rasayan</span>
+      </a>
+      <button class="nav__toggle" id="navToggle" aria-label="Menü öffnen">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="nav__links" id="navLinks">
+        <li><a href="/satnam/artikel/was-ist-sat-nam-rasayan.html">Was ist SNR?</a></li>
+        <li><a href="/satnam/artikel/sat-nam-rasayan-vs-reiki.html">SNR vs. Reiki</a></li>
+        <li><a href="/satnam/artikel/sat-kriya-anleitung.html">Sat Kriya</a></li>
+        <li><a href="/satnam/blog.html">Blog</a></li>
+        <li><a href="/satnam/glossar.html">Glossar</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Article Hero -->
+  <header class="article-hero">
+    <nav class="article-hero__breadcrumb" aria-label="Breadcrumb">
+      <a href="/satnam/">Start</a> › <a href="/satnam/blog.html">Artikel</a> › Was ist Sat Nam Rasayan?
+    </nav>
+    <span class="article-hero__tag">Pillar-Artikel</span>
+    <h1>Was ist Sat Nam Rasayan? Die meditative Heilkunst aus dem Kundalini Yoga – einfach erklärt</h1>
+    <div class="article-hero__meta">
+      <span>Aktualisiert: März 2026</span>
+      <span>·</span>
+      <span>15 Min. Lesezeit</span>
+    </div>
+  </header>
+
+  <!-- Article Content -->
+  <article class="article-content">
+
+    <p>
+      Sat Nam Rasayan ist eine jahrtausendealte meditative Heilkunst, die ihre Wurzeln in der Tradition des Kundalini Yoga hat. 
+      Übersetzt bedeutet der Name „Heilen durch das Fließen der Seele" – und genau das beschreibt den Kern der Methode: 
+      Heilung geschieht nicht durch Medikamente, Berührung oder das Senden von Energie, sondern allein durch die meditative 
+      Präsenz und Aufmerksamkeit des Praktizierenden.
+    </p>
+
+    <p>
+      In einer Zeit, in der immer mehr Menschen nach Alternativen zur reinen Schulmedizin suchen, gewinnt Sat Nam Rasayan 
+      zunehmend an Bedeutung – besonders im deutschsprachigen Raum. Doch was genau passiert bei einer Behandlung? 
+      Wie unterscheidet sich die Methode von Reiki oder anderen energetischen Heilverfahren? Und kann man sie selbst erlernen?
+    </p>
+
+    <h2>Die Bedeutung des Namens</h2>
+
+    <p>
+      Der Name setzt sich aus zwei Sanskrit-Begriffen zusammen: <strong>Sat Nam</strong> bedeutet „wahre Identität" oder „Seele", 
+      und <strong>Rasayan</strong> wird oft mit „Fließen" oder „tiefe Entspannung" übersetzt. Zusammen ergibt sich: 
+      „Tiefe Entspannung in der wahren Identität" oder freier übersetzt: „Heilung durch das Fließen der Seele".
+    </p>
+
+    <p>
+      Diese Übersetzung deutet bereits auf das Wesen der Methode hin: Es geht nicht darum, etwas zu „machen" oder 
+      von außen einzugreifen. Stattdessen wird ein meditativer Raum geschaffen, in dem der natürliche Fluss der 
+      Lebensenergie wiederhergestellt werden kann.
+    </p>
+
+    <h2>Wie funktioniert Sat Nam Rasayan?</h2>
+
+    <p>
+      Das Grundprinzip ist erstaunlich einfach – und gleichzeitig tiefgründig: Der Praktizierende begibt sich in 
+      einen spezifischen meditativen Zustand, der im Kundalini Yoga als <strong>Shuniya</strong> bezeichnet wird. 
+      Shuniya bedeutet „Nullpunkt" oder „tiefe Stille" und beschreibt einen Bewusstseinszustand jenseits von 
+      Gedanken, Bewertungen und Reaktionen.
+    </p>
+
+    <p>
+      In diesem Zustand der neutralen Präsenz nimmt der Praktizierende die innere Erfahrungswelt des Klienten wahr – 
+      nicht durch Analyse oder Diagnose, sondern durch ein direktes, fühlendes Gewahrsein. Widerstände und Blockaden, 
+      die sich als Spannungen, Schmerzen oder emotionale Muster zeigen, werden nicht bekämpft, sondern im meditativen 
+      Raum aufgelöst.
+    </p>
+
+    <div class="info-box">
+      <h4>Kernprinzip</h4>
+      <p>
+        Sat Nam Rasayan nutzt ausschließlich Aufmerksamkeit und transzendentes Bewusstsein. 
+        Es wird keine Energie gesendet, kein Ritual vollzogen und keine Diagnose gestellt. 
+        Die Heilung geschieht durch die Kraft der inneren Stille.
+      </p>
+    </div>
+
+    <h2>Was passiert bei einer Behandlung?</h2>
+
+    <p>
+      Eine typische Sat Nam Rasayan Behandlung folgt einem einfachen Ablauf:
+    </p>
+
+    <div class="step">
+      <div class="step__number">1</div>
+      <div class="step__content">
+        <h4>Ankommen & Kurzgespräch</h4>
+        <p>Du teilst kurz mit, was dich bewegt oder wo du Unterstützung suchst. Das ist hilfreich, aber nicht zwingend nötig – die Methode funktioniert auch ohne Vorinformation.</p>
+      </div>
+    </div>
+
+    <div class="step">
+      <div class="step__number">2</div>
+      <div class="step__content">
+        <h4>Hinlegen & Entspannen</h4>
+        <p>Du liegst bequem auf dem Rücken auf einer Matte, zugedeckt und vollständig bekleidet. Deine einzige „Aufgabe": nichts tun, einfach sein.</p>
+      </div>
+    </div>
+
+    <div class="step">
+      <div class="step__number">3</div>
+      <div class="step__content">
+        <h4>Meditative Behandlung</h4>
+        <p>Der Praktizierende sitzt neben dir, berührt sanft deinen Arm und geht in tiefe Meditation. In diesem Zustand nimmt er oder sie Widerstände in deinem System wahr und löst sie auf. Du spürst oft tiefe Entspannung, Wärme oder emotionale Bewegung.</p>
+      </div>
+    </div>
+
+    <div class="step">
+      <div class="step__number">4</div>
+      <div class="step__content">
+        <h4>Nachgespräch</h4>
+        <p>Nach der Behandlung (ca. 45–60 Minuten) gibt es Raum, über deine Erfahrungen zu sprechen. Manchmal erhältst du eine „Hausaufgabe" – eine Meditation, ein Mantra oder eine Übung für den Alltag.</p>
+      </div>
+    </div>
+
+    <h2>Was berichten Klienten?</h2>
+
+    <p>
+      Die häufigsten Rückmeldungen nach einer Sat Nam Rasayan Behandlung sind: ungewöhnlich tiefe Entspannung, 
+      ein Gefühl von Leichtigkeit und Klarheit, sowie die Linderung hartnäckiger körperlicher oder emotionaler 
+      Beschwerden. Manche beschreiben es so, als würde eine Last von ihnen abfallen, die sie schon lange 
+      mit sich getragen haben.
+    </p>
+
+    <p>
+      Besonders häufig wird Sat Nam Rasayan bei folgenden Themen in Anspruch genommen: Spannungszustände 
+      und innere Unruhe, Schlafstörungen, emotionale Blockaden, chronische Schmerzen und als Begleitung 
+      in Lebenskrisen oder Umbruchphasen.
+    </p>
+
+    <div class="info-box">
+      <h4>Wichtiger Hinweis</h4>
+      <p>
+        Sat Nam Rasayan versteht sich als Ergänzung, nicht als Ersatz für schulmedizinische Behandlung. 
+        Mit der Methode sind keine Heilversprechen verbunden. Bei gesundheitlichen Beschwerden sollte 
+        immer ein Arzt konsultiert werden.
+      </p>
+    </div>
+
+    <h2>Die Geschichte: Von der geheimen Tradition zur öffentlichen Lehre</h2>
+
+    <p>
+      Über Jahrtausende war Sat Nam Rasayan eine streng gehütete yogische Tradition. Das Wissen wurde 
+      ausschließlich in Stille von einem Meister an einen einzigen Schüler weitergegeben – ein Prozess, 
+      der oft mehrere Jahre dauerte.
+    </p>
+
+    <p>
+      Diese Tradition wurde von Yogi Bhajan, dem Begründer des modernen Kundalini Yoga, an 
+      Guru Dev Singh (1948–2020) weitergegeben. Yogi Bhajan beauftragte Guru Dev Singh als ersten 
+      in der Geschichte, eine öffentliche Schule zu gründen und das Wissen der Welt zugänglich zu machen. 
+      1993 wurde die Sat Nam Rasayan Schule gegründet.
+    </p>
+
+    <p>
+      Heute gibt es Ausbildungszentren in vielen Ländern – in Deutschland unter anderem in Berlin, 
+      Düsseldorf und München. Die Leitung der internationalen Schule liegt bei Sadhu Singh, 
+      einem direkten Schüler von Yogi Bhajan und Guru Dev Singh.
+    </p>
+
+    <h2>Sat Nam Rasayan und Kundalini Yoga</h2>
+
+    <p>
+      Kundalini Yoga und Sat Nam Rasayan sind in den Lehren Yogi Bhajans eng miteinander verbunden. 
+      Kundalini Yoga kann als der Übungsweg verstanden werden – die tägliche Praxis mit Kriyas, 
+      Meditationen und Mantras. Sat Nam Rasayan ist der meditative Zustand, den man auf diesem 
+      Weg im besten Fall erreicht: ein Zustand des Einsseins, der neutralen Präsenz und der 
+      Fähigkeit zu heilen.
+    </p>
+
+    <p>
+      Wer Kundalini Yoga praktiziert, findet in Sat Nam Rasayan eine Vertiefung seiner meditativen 
+      Fähigkeiten. Umgekehrt braucht man aber keine Yoga-Erfahrung, um Sat Nam Rasayan zu erlernen 
+      oder eine Behandlung zu empfangen.
+    </p>
+
+    <h2>Für wen ist Sat Nam Rasayan geeignet?</h2>
+
+    <p>
+      Grundsätzlich ist Sat Nam Rasayan für jeden zugänglich – unabhängig von Alter, Hintergrund 
+      oder spiritueller Vorerfahrung. Besonders angesprochen fühlen sich:
+    </p>
+
+    <ul>
+      <li>Menschen, die nach tiefer Entspannung und innerer Ruhe suchen</li>
+      <li>Yoga-Praktizierende, die ihre meditative Praxis vertiefen möchten</li>
+      <li>Therapeuten und Heilpraktiker, die ihre Arbeit um eine meditative Dimension erweitern wollen</li>
+      <li>Menschen in Lebenskrisen oder Übergangsphasen, die Unterstützung auf energetischer Ebene suchen</li>
+      <li>Alle, die sich für Meditation und Bewusstseinsarbeit interessieren</li>
+    </ul>
+
+    <p>
+      Bei schweren psychischen Erkrankungen sollte vor der Teilnahme an einer Ausbildung ärztlicher 
+      Rat eingeholt werden.
+    </p>
+
+    <h2>Die Ausbildung: Vom Practitioner zum Heiler</h2>
+
+    <p>
+      Die Ausbildung in Sat Nam Rasayan ist in zwei Stufen aufgebaut:
+    </p>
+
+    <p>
+      <strong>Stufe 1 – Practitioner:</strong> 12 Ausbildungstage über circa ein Jahr. 
+      Du lernst, deinen meditativen Geist zu stabilisieren und erste Behandlungen zu geben. 
+      Kosten variieren je nach Standort, liegen aber typischerweise im Bereich von 1.500–2.500 Euro.
+    </p>
+
+    <p>
+      <strong>Stufe 2 – Heiler:</strong> Circa 2,5 Jahre mit 5 Themenbereichen. 
+      Die Wahrnehmungsfähigkeit wird verfeinert, und du lernst, präzise und differenziert zu arbeiten.
+    </p>
+
+    <p>
+      Ausbildungsorte in Deutschland sind unter anderem Berlin, Düsseldorf und München. 
+      Die Stufe 2 kann in beliebiger Reihenfolge und auch mit zeitlichem Abstand besucht werden.
+    </p>
+
+    <h2>Fernbehandlung: Heilen auf Distanz</h2>
+
+    <p>
+      Ein besonderer Aspekt von Sat Nam Rasayan ist die Möglichkeit der Fernbehandlung. 
+      Da die Methode nicht auf physischer Berührung basiert, sondern auf der meditativen 
+      Verbindung zwischen Praktizierendem und Klient, ist räumliche Nähe nicht zwingend erforderlich.
+    </p>
+
+    <p>
+      In der Praxis funktioniert das so: Zum vereinbarten Zeitpunkt legt sich der Klient zu Hause 
+      hin und entspannt sich. Der Praktizierende geht in die meditative Behandlung. Anschließend 
+      findet ein telefonisches Nachgespräch statt. Viele Praktizierende berichten, dass die 
+      Fernbehandlung ebenso wirkungsvoll ist wie die Behandlung vor Ort.
+    </p>
+
+    <!-- FAQ Section -->
+    <h2>Häufig gestellte Fragen</h2>
+
+    <div class="faq-section">
+      <details class="faq-item">
+        <summary>Was ist Sat Nam Rasayan?</summary>
+        <div class="faq-answer">
+          <p>Sat Nam Rasayan ist eine meditative Heilkunst aus der Tradition des Kundalini Yoga. Der Praktizierende nutzt ausschließlich seine meditative Präsenz und Aufmerksamkeit, um Blockaden im Klienten zu lösen. Es wird keine Energie gesendet oder visualisiert – die Heilung geschieht durch die Kraft der inneren Stille.</p>
+        </div>
+      </details>
+
+      <details class="faq-item">
+        <summary>Wie funktioniert eine Sat Nam Rasayan Behandlung?</summary>
+        <div class="faq-answer">
+          <p>Der Klient liegt entspannt auf einer Matte. Der Praktizierende sitzt daneben, berührt leicht den Arm des Klienten und geht in einen tiefen meditativen Zustand (Shuniya). In dieser Stille werden Widerstände und Blockaden wahrgenommen und aufgelöst. Eine Sitzung dauert in der Regel 45–60 Minuten.</p>
+        </div>
+      </details>
+
+      <details class="faq-item">
+        <summary>Brauche ich Yoga-Erfahrung für Sat Nam Rasayan?</summary>
+        <div class="faq-answer">
+          <p>Nein. Für eine Behandlung als Klient sind keinerlei Vorkenntnisse nötig. Auch die Ausbildung zum Practitioner erfordert keine vorherige Yoga-Erfahrung. Die Praxis ist so gestaltet, dass sie für jeden zugänglich ist.</p>
+        </div>
+      </details>
+
+      <details class="faq-item">
+        <summary>Was kostet eine Sat Nam Rasayan Behandlung?</summary>
+        <div class="faq-answer">
+          <p>Eine Einzelbehandlung von ca. 60 Minuten kostet in Deutschland zwischen 75 und 100 Euro. Fernbehandlungen liegen oft im gleichen Preisbereich. Manche Praktizierende bieten auch Ermäßigungen oder Paketpreise an.</p>
+        </div>
+      </details>
+
+      <details class="faq-item">
+        <summary>Ist Sat Nam Rasayan das gleiche wie Reiki?</summary>
+        <div class="faq-answer">
+          <p>Nein. Obwohl beide Methoden äußerlich ähnlich wirken, unterscheiden sie sich grundlegend im Ansatz: Reiki arbeitet mit dem gezielten Senden von Energie über bestimmte Frequenzen. Sat Nam Rasayan hingegen arbeitet ausschließlich mit meditativer Präsenz und Stille, ohne Energie zu lenken oder zu senden. Einen ausführlichen Vergleich findest du in unserem Artikel <a href="/satnam/artikel/sat-nam-rasayan-vs-reiki.html">Sat Nam Rasayan vs. Reiki</a>.</p>
+        </div>
+      </details>
+
+      <details class="faq-item">
+        <summary>Kann ich Sat Nam Rasayan auch auf Distanz empfangen?</summary>
+        <div class="faq-answer">
+          <p>Ja. Da Sat Nam Rasayan auf meditativer Verbindung basiert und nicht auf physischer Berührung, sind Fernbehandlungen möglich und nach Erfahrung vieler Praktizierender ebenso wirkungsvoll wie Behandlungen vor Ort.</p>
+        </div>
+      </details>
+    </div>
+
+    <!-- Internal Links -->
+    <h2>Weiterführende Artikel</h2>
+    <ul>
+      <li><a href="/satnam/artikel/sat-nam-rasayan-vs-reiki.html">Sat Nam Rasayan vs. Reiki: Der ehrliche Vergleich</a></li>
+      <li><a href="/satnam/artikel/sat-nam-rasayan-erfahrungen.html">Erfahrungen: Was passiert bei einer SNR Behandlung?</a></li>
+      <li><a href="/satnam/artikel/sat-kriya-anleitung.html">Sat Kriya: Die wichtigste Kundalini Yoga Übung</a></li>
+      <li><a href="/satnam/glossar.html#shuniya">Glossar: Was ist Shuniya?</a></li>
+    </ul>
+
+  </article>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer__grid">
+        <div class="footer__brand">
+          <span class="nav__logo-mark">◯</span>
+          <span class="nav__logo-text">Sat Nam Rasayan</span>
+          <p class="footer__tagline">Heilung durch innere Stille.<br>Wissen für den deutschsprachigen Raum.</p>
+        </div>
+        <div class="footer__col">
+          <h4>Sat Nam Rasayan</h4>
+          <ul>
+            <li><a href="/satnam/artikel/was-ist-sat-nam-rasayan.html">Was ist SNR?</a></li>
+            <li><a href="/satnam/artikel/sat-nam-rasayan-vs-reiki.html">SNR vs. Reiki</a></li>
+            <li><a href="/satnam/artikel/sat-nam-rasayan-erfahrungen.html">Erfahrungen</a></li>
+          </ul>
+        </div>
+        <div class="footer__col">
+          <h4>Kundalini Kriyas</h4>
+          <ul>
+            <li><a href="/satnam/artikel/sat-kriya-anleitung.html">Sat Kriya</a></li>
+            <li><a href="/satnam/artikel/40-tage-kriya-challenge.html">40-Tage-Challenge</a></li>
+            <li><a href="/satnam/artikel/kriya-gegen-angst.html">Kriya gegen Angst</a></li>
+          </ul>
+        </div>
+        <div class="footer__col">
+          <h4>Mehr</h4>
+          <ul>
+            <li><a href="/satnam/glossar.html">Glossar</a></li>
+            <li><a href="/satnam/blog.html">Alle Artikel</a></li>
+            <li><a href="/satnam/impressum.html">Impressum</a></li>
+            <li><a href="/satnam/datenschutz.html">Datenschutz</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer__bottom">
+        <p>© 2026 Sat Nam Rasayan Wissen. Kein Ersatz für medizinische Beratung.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/main.js"></script>
+</body>
+</html>

--- a/public/satnam/css/style.css
+++ b/public/satnam/css/style.css
@@ -1,0 +1,995 @@
+/* ==========================================================================
+   SAT NAM RASAYAN – Design System
+   Aesthetic: Warm editorial / organic minimalism
+   Fonts: Cormorant Garamond (display) + DM Sans (body)
+   ========================================================================== */
+
+/* --- CSS Variables --- */
+:root {
+  /* Colors – warm, earthy, golden */
+  --c-bg: #FAF7F2;
+  --c-bg-warm: #F3EDE4;
+  --c-bg-deep: #E8DFD1;
+  --c-surface: #FFFFFF;
+  --c-text: #2C2416;
+  --c-text-soft: #6B5D4F;
+  --c-text-muted: #9B8E7E;
+  --c-accent: #C4873B;
+  --c-accent-hover: #A66E2B;
+  --c-accent-soft: #E8CFA3;
+  --c-gold: #D4A853;
+  --c-sage: #7A8B6F;
+  --c-sage-soft: #C5D1BC;
+  --c-border: #DDD5C8;
+  --c-border-light: #EDE8E0;
+
+  /* Typography */
+  --f-display: 'Cormorant Garamond', Georgia, serif;
+  --f-body: 'DM Sans', -apple-system, sans-serif;
+  
+  /* Spacing */
+  --s-xs: 0.25rem;
+  --s-sm: 0.5rem;
+  --s-md: 1rem;
+  --s-lg: 1.5rem;
+  --s-xl: 2.5rem;
+  --s-2xl: 4rem;
+  --s-3xl: 6rem;
+  --s-4xl: 8rem;
+
+  /* Layout */
+  --max-w: 1200px;
+  --max-w-text: 720px;
+
+  /* Transitions */
+  --ease: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* --- Reset & Base --- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--f-body);
+  font-weight: 400;
+  line-height: 1.7;
+  color: var(--c-text);
+  background: var(--c-bg);
+}
+
+a { color: var(--c-accent); text-decoration: none; transition: color 0.3s var(--ease); }
+a:hover { color: var(--c-accent-hover); }
+
+img { max-width: 100%; height: auto; display: block; }
+
+h1, h2, h3, h4, h5 {
+  font-family: var(--f-display);
+  font-weight: 400;
+  line-height: 1.2;
+  color: var(--c-text);
+}
+
+/* --- Utility --- */
+.container {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--s-lg);
+}
+
+/* --- Navigation --- */
+.nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: rgba(250, 247, 242, 0.85);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.4s var(--ease), background 0.4s var(--ease);
+}
+
+.nav--scrolled {
+  border-bottom-color: var(--c-border-light);
+  background: rgba(250, 247, 242, 0.95);
+}
+
+.nav__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--s-lg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 72px;
+}
+
+.nav__logo {
+  display: flex;
+  align-items: center;
+  gap: var(--s-sm);
+  text-decoration: none;
+  color: var(--c-text);
+}
+
+.nav__logo-mark {
+  font-size: 1.5rem;
+  color: var(--c-accent);
+  opacity: 0.8;
+}
+
+.nav__logo-text {
+  font-family: var(--f-display);
+  font-size: 1.25rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.nav__links {
+  display: flex;
+  list-style: none;
+  gap: var(--s-xl);
+}
+
+.nav__links a {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--c-text-soft);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  position: relative;
+  padding: var(--s-xs) 0;
+}
+
+.nav__links a::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 0;
+  height: 1.5px;
+  background: var(--c-accent);
+  transition: width 0.4s var(--ease-out);
+}
+
+.nav__links a:hover::after { width: 100%; }
+.nav__links a:hover { color: var(--c-text); }
+
+.nav__toggle {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+}
+
+.nav__toggle span {
+  display: block;
+  width: 24px;
+  height: 2px;
+  background: var(--c-text);
+  transition: all 0.3s var(--ease);
+}
+
+/* --- Hero --- */
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  padding: var(--s-4xl) var(--s-lg) var(--s-3xl);
+}
+
+.hero__bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.hero__gradient {
+  position: absolute;
+  inset: 0;
+  background: 
+    radial-gradient(ellipse 80% 60% at 20% 40%, rgba(196, 135, 59, 0.08) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 80% at 80% 60%, rgba(122, 139, 111, 0.06) 0%, transparent 60%),
+    radial-gradient(ellipse 100% 100% at 50% 0%, rgba(212, 168, 83, 0.05) 0%, transparent 50%);
+}
+
+.hero__grain {
+  position: absolute;
+  inset: 0;
+  opacity: 0.3;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.4'/%3E%3C/svg%3E");
+  background-size: 128px 128px;
+}
+
+.hero__content {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  max-width: 780px;
+  animation: fadeUp 1s var(--ease-out) both;
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(30px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.hero__kicker {
+  font-family: var(--f-body);
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--c-accent);
+  margin-bottom: var(--s-lg);
+}
+
+.hero__title {
+  font-family: var(--f-display);
+  font-size: clamp(3rem, 7vw, 5.5rem);
+  font-weight: 300;
+  line-height: 1.05;
+  color: var(--c-text);
+  margin-bottom: var(--s-xl);
+}
+
+.hero__title em {
+  font-style: italic;
+  color: var(--c-accent);
+}
+
+.hero__subtitle {
+  font-size: 1.125rem;
+  line-height: 1.8;
+  color: var(--c-text-soft);
+  max-width: 560px;
+  margin: 0 auto var(--s-xl);
+}
+
+.hero__cta {
+  display: flex;
+  gap: var(--s-md);
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.hero__scroll {
+  position: absolute;
+  bottom: var(--s-xl);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s-sm);
+  z-index: 1;
+  animation: fadeUp 1s var(--ease-out) 0.5s both;
+}
+
+.hero__scroll span {
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--c-text-muted);
+}
+
+.hero__scroll-line {
+  width: 1px;
+  height: 40px;
+  background: var(--c-border);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero__scroll-line::after {
+  content: '';
+  position: absolute;
+  top: -100%;
+  left: 0;
+  width: 100%;
+  height: 50%;
+  background: var(--c-accent);
+  animation: scrollLine 2s var(--ease) infinite;
+}
+
+@keyframes scrollLine {
+  0% { top: -50%; }
+  100% { top: 150%; }
+}
+
+/* --- Buttons --- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--f-body);
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  padding: 0.875rem 2rem;
+  border-radius: 100px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.35s var(--ease);
+}
+
+.btn--primary {
+  background: var(--c-accent);
+  color: #fff;
+}
+.btn--primary:hover {
+  background: var(--c-accent-hover);
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 8px 24px rgba(196, 135, 59, 0.25);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--c-text);
+  border: 1.5px solid var(--c-border);
+}
+.btn--ghost:hover {
+  border-color: var(--c-accent);
+  color: var(--c-accent);
+}
+
+/* --- Sections --- */
+.section {
+  padding: var(--s-3xl) 0;
+}
+
+.section__header {
+  margin-bottom: var(--s-2xl);
+}
+
+.section__label {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--c-accent);
+  margin-bottom: var(--s-sm);
+}
+
+.section__title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 400;
+}
+
+.section__desc {
+  font-size: 1.05rem;
+  color: var(--c-text-soft);
+  max-width: 540px;
+  margin-top: var(--s-md);
+  line-height: 1.8;
+}
+
+/* --- Featured Cards --- */
+.featured__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--s-xl);
+}
+
+.card {
+  position: relative;
+}
+
+.card--large {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border-light);
+  border-radius: 16px;
+  padding: var(--s-xl);
+  transition: all 0.4s var(--ease);
+}
+
+.card--large:hover {
+  border-color: var(--c-accent-soft);
+  box-shadow: 0 12px 40px rgba(44, 36, 22, 0.06);
+  transform: translateY(-3px);
+}
+
+.card__tag {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--c-sage);
+  background: var(--c-sage-soft);
+  padding: 4px 12px;
+  border-radius: 100px;
+  margin-bottom: var(--s-md);
+}
+
+.card__category {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--c-text-muted);
+  margin-bottom: var(--s-sm);
+}
+
+.card__title {
+  font-size: 1.6rem;
+  font-weight: 500;
+  line-height: 1.3;
+  margin-bottom: var(--s-md);
+}
+
+.card__title a {
+  color: var(--c-text);
+  text-decoration: none;
+}
+.card__title a:hover { color: var(--c-accent); }
+
+.card__excerpt {
+  font-size: 0.95rem;
+  color: var(--c-text-soft);
+  line-height: 1.7;
+  margin-bottom: var(--s-lg);
+}
+
+.card__meta {
+  display: flex;
+  gap: var(--s-sm);
+  font-size: 0.8rem;
+  color: var(--c-text-muted);
+}
+
+/* --- Kriya Cards --- */
+.kriyas { background: var(--c-bg-warm); }
+
+.kriyas__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--s-lg);
+}
+
+.card--kriya {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border-light);
+  border-radius: 12px;
+  padding: var(--s-xl);
+  transition: all 0.4s var(--ease);
+  position: relative;
+  overflow: hidden;
+}
+
+.card--kriya:hover {
+  border-color: var(--c-accent-soft);
+  box-shadow: 0 8px 30px rgba(44, 36, 22, 0.06);
+  transform: translateY(-2px);
+}
+
+.card__number {
+  font-family: var(--f-display);
+  font-size: 3rem;
+  font-weight: 300;
+  color: var(--c-border);
+  position: absolute;
+  top: var(--s-md);
+  right: var(--s-lg);
+  line-height: 1;
+}
+
+.card--kriya .card__title {
+  font-size: 1.3rem;
+}
+
+.card__tags-list {
+  display: flex;
+  gap: var(--s-sm);
+  list-style: none;
+  margin-top: var(--s-md);
+}
+
+.card__tags-list li {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  color: var(--c-text-muted);
+  background: var(--c-bg);
+  padding: 4px 10px;
+  border-radius: 100px;
+}
+
+/* --- Quote Band --- */
+.band {
+  padding: var(--s-3xl) 0;
+  background: var(--c-text);
+  color: var(--c-bg);
+  position: relative;
+  overflow: hidden;
+}
+
+.band::before {
+  content: '✦';
+  position: absolute;
+  top: 50%;
+  left: 5%;
+  transform: translateY(-50%);
+  font-size: 8rem;
+  opacity: 0.03;
+  color: var(--c-gold);
+}
+
+.band__inner {
+  max-width: var(--max-w-text);
+  margin: 0 auto;
+  padding: 0 var(--s-lg);
+  text-align: center;
+}
+
+.band__text h2 {
+  font-family: var(--f-display);
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 300;
+  font-style: italic;
+  line-height: 1.5;
+  color: var(--c-bg);
+  opacity: 0.9;
+}
+
+.band__attribution {
+  font-family: var(--f-body);
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--c-accent);
+  margin-top: var(--s-lg);
+}
+
+/* --- Topic Cards / Glossar --- */
+.topics__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--s-md);
+}
+
+.topic-card {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border-light);
+  border-radius: 12px;
+  padding: var(--s-lg);
+  text-decoration: none;
+  transition: all 0.35s var(--ease);
+}
+
+.topic-card:hover {
+  border-color: var(--c-accent-soft);
+  box-shadow: 0 6px 20px rgba(44, 36, 22, 0.05);
+  transform: translateY(-2px);
+}
+
+.topic-card h3 {
+  font-family: var(--f-display);
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: var(--c-text);
+  margin-bottom: var(--s-sm);
+}
+
+.topic-card p {
+  font-size: 0.85rem;
+  color: var(--c-text-soft);
+  line-height: 1.6;
+}
+
+/* --- CTA Section --- */
+.cta-section { background: var(--c-bg-warm); }
+
+.cta-box {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border-light);
+  border-radius: 20px;
+  padding: var(--s-2xl);
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.cta-box h2 {
+  font-size: 1.8rem;
+  margin-bottom: var(--s-md);
+}
+
+.cta-box > p {
+  font-size: 0.95rem;
+  color: var(--c-text-soft);
+  margin-bottom: var(--s-xl);
+}
+
+.cta-box__form {
+  display: flex;
+  gap: var(--s-sm);
+  max-width: 440px;
+  margin: 0 auto;
+}
+
+.cta-box__form input {
+  flex: 1;
+  font-family: var(--f-body);
+  font-size: 0.875rem;
+  padding: 0.875rem 1.25rem;
+  border: 1.5px solid var(--c-border);
+  border-radius: 100px;
+  background: var(--c-bg);
+  color: var(--c-text);
+  outline: none;
+  transition: border-color 0.3s var(--ease);
+}
+
+.cta-box__form input:focus {
+  border-color: var(--c-accent);
+}
+
+.cta-box__note {
+  font-size: 0.75rem;
+  color: var(--c-text-muted);
+  margin-top: var(--s-md);
+}
+
+/* --- Footer --- */
+.footer {
+  background: var(--c-text);
+  color: var(--c-bg);
+  padding: var(--s-3xl) 0 var(--s-xl);
+}
+
+.footer__grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: var(--s-2xl);
+  margin-bottom: var(--s-2xl);
+}
+
+.footer__brand .nav__logo-mark { color: var(--c-accent); }
+.footer__brand .nav__logo-text { color: var(--c-bg); }
+
+.footer__tagline {
+  font-size: 0.85rem;
+  color: rgba(250, 247, 242, 0.5);
+  margin-top: var(--s-md);
+  line-height: 1.6;
+}
+
+.footer__col h4 {
+  font-family: var(--f-body);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(250, 247, 242, 0.4);
+  margin-bottom: var(--s-lg);
+}
+
+.footer__col ul { list-style: none; }
+
+.footer__col li { margin-bottom: var(--s-sm); }
+
+.footer__col a {
+  font-size: 0.875rem;
+  color: rgba(250, 247, 242, 0.7);
+  transition: color 0.3s var(--ease);
+}
+.footer__col a:hover { color: var(--c-accent); }
+
+.footer__bottom {
+  border-top: 1px solid rgba(250, 247, 242, 0.08);
+  padding-top: var(--s-xl);
+}
+
+.footer__bottom p {
+  font-size: 0.75rem;
+  color: rgba(250, 247, 242, 0.3);
+}
+
+/* --- Article Page --- */
+.article-hero {
+  padding: calc(72px + var(--s-3xl)) var(--s-lg) var(--s-2xl);
+  max-width: var(--max-w-text);
+  margin: 0 auto;
+}
+
+.article-hero__breadcrumb {
+  font-size: 0.75rem;
+  color: var(--c-text-muted);
+  margin-bottom: var(--s-lg);
+}
+
+.article-hero__breadcrumb a { color: var(--c-text-muted); }
+.article-hero__breadcrumb a:hover { color: var(--c-accent); }
+
+.article-hero__tag {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--c-sage);
+  background: var(--c-sage-soft);
+  padding: 4px 12px;
+  border-radius: 100px;
+  margin-bottom: var(--s-lg);
+}
+
+.article-hero h1 {
+  font-size: clamp(2.2rem, 5vw, 3.2rem);
+  font-weight: 400;
+  line-height: 1.15;
+  margin-bottom: var(--s-lg);
+}
+
+.article-hero__meta {
+  font-size: 0.8rem;
+  color: var(--c-text-muted);
+  display: flex;
+  gap: var(--s-md);
+}
+
+/* Article Content */
+.article-content {
+  max-width: var(--max-w-text);
+  margin: 0 auto;
+  padding: var(--s-xl) var(--s-lg) var(--s-3xl);
+}
+
+.article-content h2 {
+  font-size: 1.8rem;
+  margin-top: var(--s-2xl);
+  margin-bottom: var(--s-md);
+  padding-top: var(--s-lg);
+  border-top: 1px solid var(--c-border-light);
+}
+
+.article-content h3 {
+  font-size: 1.35rem;
+  font-weight: 500;
+  margin-top: var(--s-xl);
+  margin-bottom: var(--s-md);
+}
+
+.article-content p {
+  margin-bottom: var(--s-lg);
+  font-size: 1.05rem;
+  line-height: 1.85;
+  color: var(--c-text-soft);
+}
+
+.article-content p:first-of-type {
+  font-size: 1.15rem;
+  color: var(--c-text);
+  line-height: 1.9;
+}
+
+.article-content ul, .article-content ol {
+  margin-bottom: var(--s-lg);
+  padding-left: var(--s-xl);
+}
+
+.article-content li {
+  margin-bottom: var(--s-sm);
+  font-size: 1rem;
+  color: var(--c-text-soft);
+  line-height: 1.7;
+}
+
+.article-content blockquote {
+  border-left: 3px solid var(--c-accent);
+  margin: var(--s-xl) 0;
+  padding: var(--s-lg) var(--s-xl);
+  background: var(--c-bg-warm);
+  border-radius: 0 12px 12px 0;
+}
+
+.article-content blockquote p {
+  font-family: var(--f-display);
+  font-size: 1.2rem;
+  font-style: italic;
+  color: var(--c-text);
+  margin-bottom: 0;
+}
+
+/* Comparison Table */
+.comparison-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--c-border-light);
+  margin: var(--s-xl) 0;
+}
+
+.comparison-table th,
+.comparison-table td {
+  padding: var(--s-md) var(--s-lg);
+  text-align: left;
+  font-size: 0.9rem;
+  border-bottom: 1px solid var(--c-border-light);
+}
+
+.comparison-table th {
+  background: var(--c-bg-warm);
+  font-family: var(--f-body);
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--c-text-soft);
+}
+
+.comparison-table td { color: var(--c-text-soft); }
+.comparison-table tr:last-child td { border-bottom: none; }
+
+/* FAQ Schema */
+.faq-section { margin-top: var(--s-2xl); }
+
+.faq-item {
+  border-bottom: 1px solid var(--c-border-light);
+  padding: var(--s-lg) 0;
+}
+
+.faq-item summary {
+  font-family: var(--f-display);
+  font-size: 1.2rem;
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--c-text);
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.faq-item summary::-webkit-details-marker { display: none; }
+
+.faq-item summary::after {
+  content: '+';
+  font-size: 1.5rem;
+  font-weight: 300;
+  color: var(--c-accent);
+  transition: transform 0.3s var(--ease);
+}
+
+.faq-item[open] summary::after {
+  transform: rotate(45deg);
+}
+
+.faq-item .faq-answer {
+  padding-top: var(--s-md);
+  font-size: 0.95rem;
+  color: var(--c-text-soft);
+  line-height: 1.8;
+}
+
+/* Info Box */
+.info-box {
+  background: var(--c-bg-warm);
+  border-radius: 12px;
+  padding: var(--s-xl);
+  margin: var(--s-xl) 0;
+  border-left: 4px solid var(--c-sage);
+}
+
+.info-box h4 {
+  font-family: var(--f-body);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--c-sage);
+  margin-bottom: var(--s-sm);
+}
+
+.info-box p {
+  font-size: 0.95rem;
+  color: var(--c-text-soft);
+  margin-bottom: 0;
+}
+
+/* Step-by-step Box */
+.step {
+  display: flex;
+  gap: var(--s-lg);
+  margin-bottom: var(--s-xl);
+  align-items: flex-start;
+}
+
+.step__number {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--c-accent);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--f-display);
+  font-size: 1.2rem;
+  font-weight: 500;
+}
+
+.step__content h4 {
+  font-family: var(--f-display);
+  font-size: 1.15rem;
+  font-weight: 500;
+  margin-bottom: var(--s-xs);
+}
+
+.step__content p {
+  font-size: 0.95rem;
+  color: var(--c-text-soft);
+  line-height: 1.7;
+  margin-bottom: 0;
+}
+
+/* --- Responsive --- */
+@media (max-width: 900px) {
+  .featured__grid { grid-template-columns: 1fr; }
+  .kriyas__grid { grid-template-columns: 1fr; }
+  .topics__grid { grid-template-columns: repeat(2, 1fr); }
+  .footer__grid { grid-template-columns: 1fr 1fr; gap: var(--s-xl); }
+}
+
+@media (max-width: 640px) {
+  .nav__links {
+    display: none;
+    position: absolute;
+    top: 72px;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    background: var(--c-bg);
+    border-bottom: 1px solid var(--c-border-light);
+    padding: var(--s-lg);
+    gap: var(--s-md);
+  }
+
+  .nav__links.active { display: flex; }
+  .nav__toggle { display: flex; }
+
+  .topics__grid { grid-template-columns: 1fr; }
+  .footer__grid { grid-template-columns: 1fr; }
+
+  .hero__title { font-size: clamp(2.4rem, 8vw, 3.5rem); }
+
+  .hero__cta { flex-direction: column; align-items: center; }
+
+  .cta-box__form { flex-direction: column; }
+  .cta-box { padding: var(--s-xl); }
+
+  .card--large { padding: var(--s-lg); }
+  .card--kriya { padding: var(--s-lg); }
+}
+
+/* --- Scroll animations --- */
+.fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s var(--ease-out), transform 0.6s var(--ease-out);
+}
+
+.fade-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/public/satnam/index.html
+++ b/public/satnam/index.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sat Nam Rasayan & Kundalini Kriyas – Heilung, Meditation & Yoga im deutschsprachigen Raum</title>
+  <meta name="description" content="Entdecke Sat Nam Rasayan – die meditative Heilkunst aus dem Kundalini Yoga. Anleitungen, Erfahrungsberichte, Kriyas und alles über die Kraft der inneren Stille.">
+  <meta name="keywords" content="Sat Nam Rasayan, Kundalini Yoga, Kriyas, meditative Heilkunst, Meditation, Yoga Deutschland">
+  <link rel="canonical" href="https://example.com/">
+  <meta property="og:title" content="Sat Nam Rasayan & Kundalini Kriyas">
+  <meta property="og:description" content="Heilung durch Stille. Die meditative Heilkunst aus dem Kundalini Yoga – einfach erklärt, mit Anleitungen und Erfahrungsberichten.">
+  <meta property="og:type" content="website">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav" id="nav">
+    <div class="nav__inner">
+      <a href="/satnam/" class="nav__logo">
+        <span class="nav__logo-mark">◯</span>
+        <span class="nav__logo-text">Sat Nam Rasayan</span>
+      </a>
+      <button class="nav__toggle" id="navToggle" aria-label="Menü öffnen">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="nav__links" id="navLinks">
+        <li><a href="/satnam/artikel/was-ist-sat-nam-rasayan.html">Was ist SNR?</a></li>
+        <li><a href="/satnam/artikel/sat-nam-rasayan-vs-reiki.html">SNR vs. Reiki</a></li>
+        <li><a href="/satnam/artikel/sat-kriya-anleitung.html">Sat Kriya</a></li>
+        <li><a href="/satnam/blog.html">Blog</a></li>
+        <li><a href="/satnam/glossar.html">Glossar</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Hero -->
+  <header class="hero">
+    <div class="hero__bg">
+      <div class="hero__grain"></div>
+      <div class="hero__gradient"></div>
+    </div>
+    <div class="hero__content">
+      <p class="hero__kicker">Die meditative Heilkunst aus dem Kundalini Yoga</p>
+      <h1 class="hero__title">
+        Heilung durch<br>
+        <em>innere Stille</em>
+      </h1>
+      <p class="hero__subtitle">
+        Sat Nam Rasayan und Kundalini Kriyas – verständlich erklärt, 
+        mit Anleitungen für deine Praxis und ehrlichen Erfahrungsberichten.
+      </p>
+      <div class="hero__cta">
+        <a href="/satnam/artikel/was-ist-sat-nam-rasayan.html" class="btn btn--primary">Was ist Sat Nam Rasayan?</a>
+        <a href="/satnam/artikel/sat-kriya-anleitung.html" class="btn btn--ghost">Erste Kriya lernen →</a>
+      </div>
+    </div>
+    <div class="hero__scroll">
+      <span>Entdecken</span>
+      <div class="hero__scroll-line"></div>
+    </div>
+  </header>
+
+  <!-- Featured Articles -->
+  <section class="section featured">
+    <div class="container">
+      <div class="section__header">
+        <span class="section__label">Pillar-Artikel</span>
+        <h2 class="section__title">Grundlagen verstehen</h2>
+      </div>
+
+      <div class="featured__grid">
+        <article class="card card--large">
+          <div class="card__tag">Pillar</div>
+          <span class="card__category">Sat Nam Rasayan</span>
+          <h3 class="card__title">
+            <a href="/satnam/artikel/was-ist-sat-nam-rasayan.html">Was ist Sat Nam Rasayan? Die meditative Heilkunst einfach erklärt</a>
+          </h3>
+          <p class="card__excerpt">
+            Sat Nam Rasayan bedeutet „Heilen durch das Fließen der Seele". 
+            Erfahre, wie diese jahrtausendealte Tradition funktioniert, was bei einer 
+            Behandlung passiert und für wen sie geeignet ist.
+          </p>
+          <div class="card__meta">
+            <span>15 Min. Lesezeit</span>
+            <span>·</span>
+            <span>Grundlagen</span>
+          </div>
+        </article>
+
+        <article class="card card--large">
+          <div class="card__tag">Vergleich</div>
+          <span class="card__category">Heilmethoden</span>
+          <h3 class="card__title">
+            <a href="/satnam/artikel/sat-nam-rasayan-vs-reiki.html">Sat Nam Rasayan vs. Reiki: Was ist der Unterschied?</a>
+          </h3>
+          <p class="card__excerpt">
+            Beide arbeiten mit Energie und Bewusstsein – aber der Ansatz ist grundlegend 
+            verschieden. Ein ehrlicher Vergleich für alle, die eine passende 
+            Heilmethode suchen.
+          </p>
+          <div class="card__meta">
+            <span>10 Min. Lesezeit</span>
+            <span>·</span>
+            <span>Vergleich</span>
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- Kriyas Section -->
+  <section class="section kriyas">
+    <div class="container">
+      <div class="section__header">
+        <span class="section__label">Kundalini Yoga</span>
+        <h2 class="section__title">Kriyas & Praxis</h2>
+        <p class="section__desc">Schritt-für-Schritt-Anleitungen für deine Kundalini Yoga Praxis – von den Grundlagen bis zu fortgeschrittenen Übungsreihen.</p>
+      </div>
+
+      <div class="kriyas__grid">
+        <article class="card card--kriya">
+          <div class="card__number">01</div>
+          <span class="card__category">How-To</span>
+          <h3 class="card__title">
+            <a href="/satnam/artikel/sat-kriya-anleitung.html">Sat Kriya: Die wichtigste Kundalini Übung</a>
+          </h3>
+          <p class="card__excerpt">Anleitung, Wirkung & Tipps für die fundamentalste Kriya im Kundalini Yoga.</p>
+          <ul class="card__tags-list">
+            <li>Anfänger geeignet</li>
+            <li>3–31 Min.</li>
+          </ul>
+        </article>
+
+        <article class="card card--kriya">
+          <div class="card__number">02</div>
+          <span class="card__category">How-To</span>
+          <h3 class="card__title">
+            <a href="/satnam/artikel/40-tage-kriya-challenge.html">Die 40-Tage-Kriya-Challenge</a>
+          </h3>
+          <p class="card__excerpt">Wie 40 Tage ununterbrochene Praxis dein Leben verändern können – ein kompletter Guide.</p>
+          <ul class="card__tags-list">
+            <li>Alle Level</li>
+            <li>40 Tage</li>
+          </ul>
+        </article>
+
+        <article class="card card--kriya">
+          <div class="card__number">03</div>
+          <span class="card__category">How-To</span>
+          <h3 class="card__title">
+            <a href="/satnam/artikel/kriya-gegen-angst.html">Kriya gegen Angst & innere Unruhe</a>
+          </h3>
+          <p class="card__excerpt">Eine kraftvolle Übungsreihe, die dein Nervensystem beruhigt und emotionale Balance fördert.</p>
+          <ul class="card__tags-list">
+            <li>Anfänger geeignet</li>
+            <li>15–30 Min.</li>
+          </ul>
+        </article>
+
+        <article class="card card--kriya">
+          <div class="card__number">04</div>
+          <span class="card__category">Erfahrung</span>
+          <h3 class="card__title">
+            <a href="/satnam/artikel/sat-nam-rasayan-erfahrungen.html">SNR Erfahrungen: Was passiert bei einer Behandlung?</a>
+          </h3>
+          <p class="card__excerpt">Ablauf, Empfindungen und was du bei deiner ersten Sat Nam Rasayan Behandlung erwarten kannst.</p>
+          <ul class="card__tags-list">
+            <li>Einsteiger</li>
+            <li>Erfahrungsbericht</li>
+          </ul>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- Info / About Band -->
+  <section class="section band">
+    <div class="band__inner">
+      <div class="band__text">
+        <h2>„Im Sat Nam Rasayan wird nichts verwendet außer der Aufmerksamkeit und dem transzendenten Bewusstsein."</h2>
+        <p class="band__attribution">— Guru Dev Singh</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Topics / Glossar Teaser -->
+  <section class="section topics">
+    <div class="container">
+      <div class="section__header">
+        <span class="section__label">Wissen</span>
+        <h2 class="section__title">Wichtige Begriffe</h2>
+      </div>
+      <div class="topics__grid">
+        <a href="/satnam/glossar.html#shuniya" class="topic-card">
+          <h3>Shuniya</h3>
+          <p>Der Zustand der absoluten Stille und Nullpunkt des Geistes – Grundlage jeder SNR-Behandlung.</p>
+        </a>
+        <a href="/satnam/glossar.html#kriya" class="topic-card">
+          <h3>Kriya</h3>
+          <p>Eine festgelegte Übungsreihe im Kundalini Yoga mit einem bestimmten energetischen Ziel.</p>
+        </a>
+        <a href="/satnam/glossar.html#pranayama" class="topic-card">
+          <h3>Pranayama</h3>
+          <p>Atemtechniken zur Kontrolle der Lebensenergie – vom Feueratem bis zur Wechselatmung.</p>
+        </a>
+        <a href="/satnam/glossar.html#feueratem" class="topic-card">
+          <h3>Feueratem</h3>
+          <p>Die kraftvolle rhythmische Atemtechnik, die in vielen Kundalini Kriyas eingesetzt wird.</p>
+        </a>
+        <a href="/satnam/glossar.html#sadhana" class="topic-card">
+          <h3>Sadhana</h3>
+          <p>Die tägliche spirituelle Praxis – idealerweise in den Amrit-Vela-Stunden vor Sonnenaufgang.</p>
+        </a>
+        <a href="/satnam/glossar.html#satnam" class="topic-card">
+          <h3>Sat Nam</h3>
+          <p>„Wahrheit ist mein Name" – das Bīj-Mantra des Kundalini Yoga und Kern der Praxis.</p>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Newsletter / CTA -->
+  <section class="section cta-section">
+    <div class="container">
+      <div class="cta-box">
+        <div class="cta-box__content">
+          <h2>Jeden Monat neue Kriyas & Impulse</h2>
+          <p>Erhalte Anleitungen, saisonale Meditationen und Hintergründe zu Sat Nam Rasayan – direkt in dein Postfach.</p>
+        </div>
+        <div class="cta-box__form">
+          <input type="email" placeholder="Deine E-Mail-Adresse" aria-label="E-Mail-Adresse">
+          <button class="btn btn--primary" type="button">Anmelden</button>
+        </div>
+        <p class="cta-box__note">Kein Spam. Jederzeit abmeldbar. Datenschutz respektiert.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer__grid">
+        <div class="footer__brand">
+          <span class="nav__logo-mark">◯</span>
+          <span class="nav__logo-text">Sat Nam Rasayan</span>
+          <p class="footer__tagline">Heilung durch innere Stille.<br>Wissen für den deutschsprachigen Raum.</p>
+        </div>
+        <div class="footer__col">
+          <h4>Sat Nam Rasayan</h4>
+          <ul>
+            <li><a href="/satnam/artikel/was-ist-sat-nam-rasayan.html">Was ist SNR?</a></li>
+            <li><a href="/satnam/artikel/sat-nam-rasayan-vs-reiki.html">SNR vs. Reiki</a></li>
+            <li><a href="/satnam/artikel/sat-nam-rasayan-erfahrungen.html">Erfahrungen</a></li>
+          </ul>
+        </div>
+        <div class="footer__col">
+          <h4>Kundalini Kriyas</h4>
+          <ul>
+            <li><a href="/satnam/artikel/sat-kriya-anleitung.html">Sat Kriya</a></li>
+            <li><a href="/satnam/artikel/40-tage-kriya-challenge.html">40-Tage-Challenge</a></li>
+            <li><a href="/satnam/artikel/kriya-gegen-angst.html">Kriya gegen Angst</a></li>
+          </ul>
+        </div>
+        <div class="footer__col">
+          <h4>Mehr</h4>
+          <ul>
+            <li><a href="/satnam/glossar.html">Glossar</a></li>
+            <li><a href="/satnam/blog.html">Alle Artikel</a></li>
+            <li><a href="/satnam/impressum.html">Impressum</a></li>
+            <li><a href="/satnam/datenschutz.html">Datenschutz</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer__bottom">
+        <p>© 2026 Sat Nam Rasayan Wissen. Kein Ersatz für medizinische Beratung.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/public/satnam/js/main.js
+++ b/public/satnam/js/main.js
@@ -1,0 +1,87 @@
+// ==========================================================================
+// SAT NAM RASAYAN – Main JS
+// ==========================================================================
+
+document.addEventListener('DOMContentLoaded', () => {
+
+  // --- Mobile Navigation ---
+  const navToggle = document.getElementById('navToggle');
+  const navLinks = document.getElementById('navLinks');
+
+  if (navToggle && navLinks) {
+    navToggle.addEventListener('click', () => {
+      navLinks.classList.toggle('active');
+      navToggle.classList.toggle('open');
+    });
+
+    // Close on link click
+    navLinks.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        navLinks.classList.remove('active');
+        navToggle.classList.remove('open');
+      });
+    });
+  }
+
+  // --- Scroll: Nav background ---
+  const nav = document.getElementById('nav');
+  let lastScroll = 0;
+
+  window.addEventListener('scroll', () => {
+    const currentScroll = window.scrollY;
+    if (currentScroll > 40) {
+      nav.classList.add('nav--scrolled');
+    } else {
+      nav.classList.remove('nav--scrolled');
+    }
+    lastScroll = currentScroll;
+  }, { passive: true });
+
+  // --- Scroll: Fade-in animations ---
+  const fadeElements = document.querySelectorAll('.card, .topic-card, .cta-box, .section__header, .step');
+
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry, index) => {
+        if (entry.isIntersecting) {
+          // Stagger the animation
+          setTimeout(() => {
+            entry.target.classList.add('fade-in', 'visible');
+          }, index * 80);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, {
+      threshold: 0.1,
+      rootMargin: '0px 0px -40px 0px'
+    });
+
+    fadeElements.forEach(el => {
+      el.classList.add('fade-in');
+      observer.observe(el);
+    });
+  }
+
+  // --- FAQ Accordion (for article pages) ---
+  document.querySelectorAll('.faq-item').forEach(item => {
+    item.addEventListener('toggle', () => {
+      if (item.open) {
+        document.querySelectorAll('.faq-item').forEach(other => {
+          if (other !== item) other.removeAttribute('open');
+        });
+      }
+    });
+  });
+
+  // --- Smooth scroll for anchor links ---
+  document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+    anchor.addEventListener('click', function (e) {
+      e.preventDefault();
+      const target = document.querySelector(this.getAttribute('href'));
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+
+});


### PR DESCRIPTION
## Summary
- Adds the Sat Nam Rasayan German-language static site to `public/satnam/`
- Updated all internal root-relative links to use `/satnam/` prefix
- Existing Next.js app is unaffected

## Test plan
- [ ] Visit `/satnam/` — homepage loads correctly
- [ ] Nav links work (articles, glossar, blog placeholders)
- [ ] `/satnam/artikel/was-ist-sat-nam-rasayan.html` loads
- [ ] `/satnam/artikel/sat-nam-rasayan-vs-reiki.html` loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)