### PR TITLE
fix: rename middleware.ts to proxy.ts (restores site)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -9,11 +9,5 @@ export default clerkMiddleware(async (auth, request) => {
 })
 
 export const config = {
-  matcher: [
-    '/admin(.*)',
-    '/dashboard(.*)',
-    '/videos(.*)',
-    '/live(.*)',
-    '/api/clerk(.*)',
-  ],
+  matcher: ['/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)'],
 }


### PR DESCRIPTION
Next.js 16 deprecated `middleware.ts` in favour of `proxy.ts`. Production was silently ignoring the old file, breaking Clerk auth context site-wide.

This restores the original broad matcher and renames the file — site should be back up immediately after deploy.