### PR TITLE
fix: sender email → info@kundaliniyogatribe.de

### DIFF
--- a/app/api/confirm/route.ts
+++ b/app/api/confirm/route.ts
@@ -20,7 +20,7 @@ export async function GET(req: NextRequest) {
   const apiKey = process.env.MAILJET_API_KEY?.trim()
   const secretKey = process.env.MAILJET_SECRET_KEY?.trim()
   const listId = process.env.MAILJET_LIST_ID?.trim()
-  const fromEmail = process.env.MAILJET_FROM_EMAIL?.trim() || 'soulconnectclub@gmail.com'
+  const fromEmail = process.env.MAILJET_FROM_EMAIL?.trim() || 'info@kundaliniyogatribe.de'
 
   if (!apiKey || !secretKey || !listId) {
     return NextResponse.redirect(`${siteUrl}/anmeldung?status=fehler`)

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -11,7 +11,7 @@ export async function POST(req: NextRequest) {
 
   const apiKey = process.env.MAILJET_API_KEY?.trim()
   const secretKey = process.env.MAILJET_SECRET_KEY?.trim()
-  const fromEmail = process.env.MAILJET_FROM_EMAIL?.trim() || 'noreply@kundaliniyogatribe.de'
+  const fromEmail = process.env.MAILJET_FROM_EMAIL?.trim() || 'info@kundaliniyogatribe.de'
   const siteUrl = 'https://kundaliniyogatribe.de'
 
   if (!apiKey || !secretKey) {


### PR DESCRIPTION
Both subscribe and confirm routes now use info@kundaliniyogatribe.de (via MAILJET_FROM_EMAIL env var) with that address as fallback.