### PR TITLE
feat: bilingual confirmation page + lang in all redirects

### DIFF
--- a/app/anmeldung/AnmeldungContent.tsx
+++ b/app/anmeldung/AnmeldungContent.tsx
@@ -12,36 +12,68 @@ const C = {
 
 type Status = 'bestaetigt' | 'abgelaufen' | 'fehler' | 'abgemeldet' | null
 
-const messages: Record<NonNullable<Status>, { icon: string; title: string; body: string }> = {
-  bestaetigt: {
-    icon: '☽',
-    title: 'Sat Nam – du bist dabei!',
-    body: 'Deine Anmeldung wurde bestätigt. Du erhältst ab jetzt Kriyas, Meditationen und Impulse aus der Welt des Kundalini Yoga.',
+const messages = {
+  de: {
+    bestaetigt: {
+      icon: '☽',
+      title: 'Sat Nam – du bist dabei!',
+      body: 'Deine Anmeldung wurde bestätigt. Du erhältst ab jetzt Kriyas, Meditationen und Impulse aus der Welt des Kundalini Yoga.',
+    },
+    abgelaufen: {
+      icon: '◔',
+      title: 'Link abgelaufen',
+      body: 'Der Bestätigungslink ist nicht mehr gültig (24 Stunden). Melde dich erneut an – wir schicken dir einen neuen Link.',
+    },
+    fehler: {
+      icon: '✦',
+      title: 'Etwas ist schiefgelaufen',
+      body: 'Es gab einen technischen Fehler. Bitte versuche es erneut oder schreib uns an info@kundaliniyogatribe.de.',
+    },
+    abgemeldet: {
+      icon: '☾',
+      title: 'Du wurdest abgemeldet',
+      body: 'Deine E-Mail-Adresse wurde aus unserem Newsletter entfernt. Du erhältst keine weiteren E-Mails von uns. Sat Nam.',
+    },
   },
-  abgelaufen: {
-    icon: '◔',
-    title: 'Link abgelaufen',
-    body: 'Der Bestätigungslink ist nicht mehr gültig (24 Stunden). Melde dich erneut an – wir schicken dir einen neuen Link.',
-  },
-  fehler: {
-    icon: '✦',
-    title: 'Etwas ist schiefgelaufen',
-    body: 'Es gab einen technischen Fehler. Bitte versuche es erneut oder schreib uns an noreply@kundaliniyogatribe.de.',
-  },
-  abgemeldet: {
-    icon: '☾',
-    title: 'Du wurdest abgemeldet',
-    body: 'Deine E-Mail-Adresse wurde aus unserem Newsletter entfernt. Du erhältst keine weiteren E-Mails von uns. Sat Nam.',
+  en: {
+    bestaetigt: {
+      icon: '☽',
+      title: "Sat Nam – you're in!",
+      body: "Your subscription is confirmed. You'll now receive Kriyas, meditations and insights from the world of Kundalini Yoga.",
+    },
+    abgelaufen: {
+      icon: '◔',
+      title: 'Link expired',
+      body: "The confirmation link is no longer valid (24 hours). Sign up again and we'll send you a new one.",
+    },
+    fehler: {
+      icon: '✦',
+      title: 'Something went wrong',
+      body: 'There was a technical error. Please try again or write to us at info@kundaliniyogatribe.de.',
+    },
+    abgemeldet: {
+      icon: '☾',
+      title: "You've been unsubscribed",
+      body: "Your email address has been removed from our list. You won't receive any further emails from us. Sat Nam.",
+    },
   },
 }
 
 export default function AnmeldungContent() {
   const params = useSearchParams()
   const status = params.get('status') as Status
+  const lang = params.get('lang') === 'en' ? 'en' : 'de'
 
-  const msg = status && messages[status]
-    ? messages[status]
-    : { icon: '◯', title: 'Kundalini Yoga Tribe', body: 'Melde dich an um Kriyas, Meditationen und Impulse zu erhalten.' }
+  const set = messages[lang]
+  const msg = status && set[status]
+    ? set[status]
+    : {
+        icon: '◯',
+        title: 'Kundalini Yoga Tribe',
+        body: lang === 'en'
+          ? 'Sign up to receive Kriyas, meditations and insights.'
+          : 'Melde dich an um Kriyas, Meditationen und Impulse zu erhalten.',
+      }
 
   return (
     <main style={{
@@ -91,7 +123,7 @@ export default function AnmeldungContent() {
             fontFamily: "'DM Sans', sans-serif",
           }}
         >
-          ← Zurück zur Website
+          {lang === 'en' ? '← Back to website' : '← Zurück zur Website'}
         </a>
       </div>
     </main>

--- a/app/api/confirm/route.ts
+++ b/app/api/confirm/route.ts
@@ -7,17 +7,19 @@ export async function GET(req: NextRequest) {
   const siteUrl = 'https://kundaliniyogatribe.de'
   const shopUrl = 'https://www.charan-amrit-kaur.de/yoga-tribe/'
 
+  const langFromUrl = req.nextUrl.searchParams.get('lang') === 'en' ? 'en' : 'de'
+
   if (!token) {
-    return NextResponse.redirect(`${siteUrl}/anmeldung?status=fehler`)
+    return NextResponse.redirect(`${siteUrl}/anmeldung?status=fehler&lang=${langFromUrl}`)
   }
 
   const email = await redis.get(`doi:${token}`)
 
   if (!email) {
-    return NextResponse.redirect(`${siteUrl}/anmeldung?status=abgelaufen`)
+    return NextResponse.redirect(`${siteUrl}/anmeldung?status=abgelaufen&lang=${langFromUrl}`)
   }
 
-  const lang = (await redis.get(`doi_lang:${token}`)) || 'de'
+  const lang = (await redis.get(`doi_lang:${token}`)) || langFromUrl
 
   const apiKey = process.env.MAILJET_API_KEY?.trim()
   const secretKey = process.env.MAILJET_SECRET_KEY?.trim()
@@ -25,7 +27,7 @@ export async function GET(req: NextRequest) {
   const fromEmail = process.env.MAILJET_FROM_EMAIL?.trim() || 'info@kundaliniyogatribe.de'
 
   if (!apiKey || !secretKey || !listId) {
-    return NextResponse.redirect(`${siteUrl}/anmeldung?status=fehler`)
+    return NextResponse.redirect(`${siteUrl}/anmeldung?status=fehler&lang=${lang}`)
   }
 
   try {
@@ -175,9 +177,9 @@ export async function GET(req: NextRequest) {
       }),
     }).catch(err => console.error('Welcome email error:', err))
 
-    return NextResponse.redirect(`${siteUrl}/anmeldung?status=bestaetigt`)
+    return NextResponse.redirect(`${siteUrl}/anmeldung?status=bestaetigt&lang=${lang}`)
   } catch (e) {
     console.error('Confirm error:', e)
-    return NextResponse.redirect(`${siteUrl}/anmeldung?status=fehler`)
+    return NextResponse.redirect(`${siteUrl}/anmeldung?status=fehler&lang=${lang}`)
   }
 }

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
   await redis.setex(`doi_lang:${token}`, 86400, lang)
   await redis.setex(`unsub:${unsubToken}`, 31536000, email)
 
-  const confirmUrl = `${siteUrl}/api/confirm?token=${token}`
+  const confirmUrl = `${siteUrl}/api/confirm?token=${token}&lang=${lang}`
   const unsubUrl = `${siteUrl}/api/unsubscribe?token=${unsubToken}`
   const credentials = Buffer.from(`${apiKey}:${secretKey}`).toString('base64')
 


### PR DESCRIPTION
- lang embedded in confirmation email link (?lang=en/de)
- Confirm route reads lang from URL param as fallback for expired tokens
- All redirects carry lang param
- AnmeldungContent shows EN/DE based on lang param
- Back link also translates